### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server implementation for Keycloak, providing a standardized interface for managing Keycloak users and realms.
 
+<a href="https://glama.ai/mcp/servers/@HaithamOumerzoug/keycloak-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@HaithamOumerzoug/keycloak-mcp/badge" alt="Keycloak Server MCP server" />
+</a>
+
 ## Description
 
 This project implements an MCP server that integrates with Keycloak, allowing you to manage Keycloak users and realms through a standardized protocol. It uses the official Keycloak Admin Client to interact with Keycloak's API.


### PR DESCRIPTION
This PR adds a badge for the [Keycloak MCP Server](https://glama.ai/mcp/servers/@HaithamOumerzoug/keycloak-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@HaithamOumerzoug/keycloak-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@HaithamOumerzoug/keycloak-mcp/badge" alt="Keycloak Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.