### PR TITLE
feat: add client role creation, protocol mapper, and user role mapping tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,48 @@ Lists all roles for a specific client in a realm.
 - `realm`: The realm name
 - `clientUniqueId`: The unique ID of the client
 
+### create-client-role
+
+Creates a role in a specific client.
+
+**Inputs**:
+
+- `realm`: The realm name
+- `clientUniqueId`: The unique ID of the client
+- `roleName`: The name of the role to create
+- `description` (optional): Role description
+
+### list-protocol-mappers
+
+Lists the protocol mappers of a client (its dedicated scope), including each mapper's config — useful to verify claim mappers (e.g. group membership / client role claims).
+
+**Inputs**:
+
+- `realm`: The realm name
+- `clientUniqueId`: The unique ID of the client
+
+### create-protocol-mapper
+
+Creates a protocol mapper on a client, e.g. a Group Membership mapper or a User Client Role mapper.
+
+**Inputs**:
+
+- `realm`: The realm name
+- `clientUniqueId`: The unique ID of the client
+- `name`: Mapper display name
+- `protocolMapper`: Mapper type id (e.g. `oidc-group-membership-mapper`, `oidc-usermodel-client-role-mapper`)
+- `protocol` (optional, default `openid-connect`)
+- `config` (optional): Mapper config map, e.g. `{"claim.name": "groups", "id.token.claim": "true", "full.path": "false"}`
+
+### list-user-role-mappings
+
+Lists all realm and client role mappings assigned to a user — answers "which roles does this user actually have?".
+
+**Inputs**:
+
+- `realm`: The realm name
+- `userId`: The ID of the user
+
 ### assign-client-role-to-user
 
 Assigns a client role to a specific user.

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -43,6 +43,32 @@ export const ListClientRolesSchema = z.object({
   clientUniqueId: z.string(),
 });
 
+export const CreateClientRoleSchema = z.object({
+  realm: z.string(),
+  clientUniqueId: z.string(),
+  roleName: z.string(),
+  description: z.string().optional(),
+});
+
+export const ListProtocolMappersSchema = z.object({
+  realm: z.string(),
+  clientUniqueId: z.string(),
+});
+
+export const CreateProtocolMapperSchema = z.object({
+  realm: z.string(),
+  clientUniqueId: z.string(),
+  name: z.string(),
+  protocolMapper: z.string(),
+  protocol: z.string().default("openid-connect"),
+  config: z.record(z.string()).default({}),
+});
+
+export const ListUserRoleMappingsSchema = z.object({
+  realm: z.string(),
+  userId: z.string(),
+});
+
 export const InputSchema = {
   "create-user": {
     type: "object",
@@ -115,6 +141,53 @@ export const InputSchema = {
       clientUniqueId: { type: "string" },
     },
     required: ["realm", "clientUniqueId"],
+  },
+  "create-client-role": {
+    type: "object",
+    properties: {
+      realm: { type: "string" },
+      clientUniqueId: { type: "string" },
+      roleName: { type: "string" },
+      description: { type: "string" },
+    },
+    required: ["realm", "clientUniqueId", "roleName"],
+  },
+  "list-protocol-mappers": {
+    type: "object",
+    properties: {
+      realm: { type: "string" },
+      clientUniqueId: { type: "string" },
+    },
+    required: ["realm", "clientUniqueId"],
+  },
+  "create-protocol-mapper": {
+    type: "object",
+    properties: {
+      realm: { type: "string" },
+      clientUniqueId: { type: "string" },
+      name: { type: "string" },
+      protocolMapper: {
+        type: "string",
+        description:
+          "Mapper type id, e.g. oidc-usermodel-client-role-mapper or oidc-group-membership-mapper",
+      },
+      protocol: { type: "string", default: "openid-connect" },
+      config: {
+        type: "object",
+        additionalProperties: { type: "string" },
+        description:
+          'Mapper config, e.g. {"claim.name": "groups", "id.token.claim": "true", "full.path": "false"}',
+      },
+    },
+    required: ["realm", "clientUniqueId", "name", "protocolMapper"],
+  },
+  "list-user-role-mappings": {
+    type: "object",
+    properties: {
+      realm: { type: "string" },
+      userId: { type: "string" },
+    },
+    required: ["realm", "userId"],
   },
 };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,6 +78,29 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description: "List roles in a specific client",
         inputSchema: InputSchema["list-client-roles"],
       },
+      {
+        name: "create-client-role",
+        description: "Create a role in a specific client",
+        inputSchema: InputSchema["create-client-role"],
+      },
+      {
+        name: "list-protocol-mappers",
+        description:
+          "List protocol mappers of a client (dedicated scope), including their config",
+        inputSchema: InputSchema["list-protocol-mappers"],
+      },
+      {
+        name: "create-protocol-mapper",
+        description:
+          "Create a protocol mapper on a client (e.g. group membership or client role claim mappers)",
+        inputSchema: InputSchema["create-protocol-mapper"],
+      },
+      {
+        name: "list-user-role-mappings",
+        description:
+          "List all realm and client role mappings assigned to a user",
+        inputSchema: InputSchema["list-user-role-mappings"],
+      },
     ],
   };
 });
@@ -152,6 +175,42 @@ server.setRequestHandler(
               {
                 type: "text",
                 text: await keycloakService.listClientRoles(args),
+              },
+            ],
+          };
+        case "create-client-role":
+          return {
+            content: [
+              {
+                type: "text",
+                text: await keycloakService.createClientRole(args),
+              },
+            ],
+          };
+        case "list-protocol-mappers":
+          return {
+            content: [
+              {
+                type: "text",
+                text: await keycloakService.listProtocolMappers(args),
+              },
+            ],
+          };
+        case "create-protocol-mapper":
+          return {
+            content: [
+              {
+                type: "text",
+                text: await keycloakService.createProtocolMapper(args),
+              },
+            ],
+          };
+        case "list-user-role-mappings":
+          return {
+            content: [
+              {
+                type: "text",
+                text: await keycloakService.listUserRoleMappings(args),
               },
             ],
           };

--- a/src/services/keycloak.ts
+++ b/src/services/keycloak.ts
@@ -8,11 +8,15 @@ import KeycloakConfig from "../config/keycloak.ts";
 import {
   AddUserToGroupSchema,
   AssignClientRoleSchema,
+  CreateClientRoleSchema,
+  CreateProtocolMapperSchema,
   CreateUserSchema,
   DeleteUserSchema,
   ListClientRolesSchema,
   ListClientsSchema,
   ListGroupsSchema,
+  ListProtocolMappersSchema,
+  ListUserRoleMappingsSchema,
   ListUsersSchema,
 } from "../schemas/index.ts";
 
@@ -125,6 +129,67 @@ class KeycloakService {
     return `Roles in client ${clientUniqueId} in realm ${realm}:\n${roles
       .map((r) => `- ${r.name}`)
       .join("\n")}`;
+  }
+
+  public async createClientRole(args: unknown): Promise<string> {
+    const { realm, clientUniqueId, roleName, description } =
+      CreateClientRoleSchema.parse(args);
+    await this.kcAdminClient.clients.createRole({
+      id: clientUniqueId,
+      realm,
+      name: roleName,
+      description,
+    });
+    return `Role '${roleName}' created in client ${clientUniqueId} in realm ${realm}`;
+  }
+
+  public async listProtocolMappers(args: unknown): Promise<string> {
+    const { realm, clientUniqueId } = ListProtocolMappersSchema.parse(args);
+    const mappers = await this.kcAdminClient.clients.listProtocolMappers({
+      id: clientUniqueId,
+      realm,
+    });
+    if (!mappers.length) {
+      return `No protocol mappers in client ${clientUniqueId} in realm ${realm}`;
+    }
+    return `Protocol mappers in client ${clientUniqueId} in realm ${realm}:\n${mappers
+      .map(
+        (m) =>
+          `- ${m.name} [${m.protocolMapper}] config=${JSON.stringify(
+            m.config ?? {}
+          )}`
+      )
+      .join("\n")}`;
+  }
+
+  public async createProtocolMapper(args: unknown): Promise<string> {
+    const { realm, clientUniqueId, name, protocolMapper, protocol, config } =
+      CreateProtocolMapperSchema.parse(args);
+    await this.kcAdminClient.clients.addProtocolMapper(
+      { id: clientUniqueId, realm },
+      { name, protocol, protocolMapper, config }
+    );
+    return `Protocol mapper '${name}' [${protocolMapper}] created in client ${clientUniqueId} in realm ${realm}`;
+  }
+
+  public async listUserRoleMappings(args: unknown): Promise<string> {
+    const { realm, userId } = ListUserRoleMappingsSchema.parse(args);
+    const mappings = await this.kcAdminClient.users.listRoleMappings({
+      id: userId,
+      realm,
+    });
+    const realmRoles = (mappings.realmMappings ?? [])
+      .map((r) => `- [realm] ${r.name}`)
+      .join("\n");
+    const clientRoles = Object.entries(mappings.clientMappings ?? {})
+      .flatMap(([client, m]: [string, any]) =>
+        (m.mappings ?? []).map((r: any) => `- [client:${client}] ${r.name}`)
+      )
+      .join("\n");
+    const all = [realmRoles, clientRoles].filter(Boolean).join("\n");
+    return all
+      ? `Role mappings for user ${userId} in realm ${realm}:\n${all}`
+      : `User ${userId} has no role mappings in realm ${realm}`;
   }
 }
 


### PR DESCRIPTION
## What

Adds four tools that round out common admin workflows, following the existing conventions (zod parse → text response, official `@keycloak/keycloak-admin-client` methods only):

| Tool | Purpose |
|---|---|
| `create-client-role` | Create a role on a client |
| `list-protocol-mappers` | Inspect a client's dedicated-scope mappers **including config** — lets an agent verify claim mappers (group membership / client role claims) instead of guessing |
| `create-protocol-mapper` | Create claim mappers with a passthrough `config` map (e.g. `oidc-group-membership-mapper`, `oidc-usermodel-client-role-mapper`) |
| `list-user-role-mappings` | Answer "which realm/client roles does this user actually have?" — the read counterpart to the existing `assign-client-role-to-user` |

## Why

While wiring role-based authorization for our services through this MCP server, we repeatedly hit the same gaps: the agent could *assign* a client role but not check what a user already has, and could not verify whether the OIDC claim mappers backing the roles/groups claims were configured. These four tools close that loop.

## Testing

- `npm run build` clean
- Exercised live against our Keycloak 26 instance over stdio JSON-RPC: `tools/list` shows 13 tools; `list-protocol-mappers` correctly dumped a `oidc-usermodel-client-role-mapper` with its config; `list-user-role-mappings` returned both realm and client mappings; `create-client-role` round-trips with `list-client-roles`.
- README updated for all four tools.